### PR TITLE
Accessibility fix

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -18,6 +18,7 @@ $(document).ready(function() {
     });
 });
 
+
 function addDirectory(data) {
     var ul = document.createElement('ul');
     data.children.forEach(function(item) {
@@ -32,6 +33,7 @@ function addDirectory(data) {
             li.classList.add("file");
         } else {
             li.appendChild(text);
+            li.tabIndex = 0
             li.appendChild(addDirectory(item));
             li.classList.add("directory");
         }


### PR DESCRIPTION
Accessibility to non mouse-based devices.

With mice, you have to click on the li elem. With keyboards, you can't.
With this fix, you can use 'tab' to select an li elem, so even without a mouse you can select a li.